### PR TITLE
Update Adafruit_BMP280.cpp

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -62,7 +62,15 @@ bool Adafruit_BMP280::begin(uint8_t a, uint8_t chipid) {
     return false;
 
   readCoefficients();
-  write8(BMP280_REGISTER_CONTROL, 0x3F);
+
+  // Set t_sb to 010 = 125ms.  Step response will settle
+  // down after three to four seconds.
+  // Set filter to 100, which means  16; recommended for ultra high resolution
+  // Set osrs_t to 010, which means  x2; recommended for ultra high resolution
+  // Set osrs_p to 101, which means x16; recommended for ultra high resolution
+
+  write8(BMP280_REGISTER_CONFIG,  0x50);  // t_sb=010  filter=100 spare=0 SPI3w_en=0 0101.0000
+  write8(BMP280_REGISTER_CONTROL, 0x57);  // osrs_t=010 osrs_p=101 mode=11 0101.0111
   return true;
 }
 


### PR DESCRIPTION
This change establishes initial values for BMP280_REGISTER_CONFIG and BMP280_REGISTER_CONTROL that are consistent with the demonstration program's two-second sample interval.  As seen in this side-by-side comparison with the prior version (which didn't set the CONFIG register at all, leaving it at the power-in default of 0x00) the resulting samples are more stable.

BMP280 test -- default REGISTER_CONFIG  BMP280 test -- 125ms REGISTER_CONFIG
Approx altitude = 34.75 m               Approx altitude = 35.75 m
Approx altitude = 34.51 m               Approx altitude = 35.80 m
Approx altitude = 34.58 m               Approx altitude = 35.77 m
Approx altitude = 34.65 m               Approx altitude = 35.75 m
Approx altitude = 34.33 m               Approx altitude = 35.79 m
Approx altitude = 34.55 m               Approx altitude = 35.77 m
Approx altitude = 34.44 m               Approx altitude = 35.74 m
Approx altitude = 34.65 m               Approx altitude = 35.73 m

A more complete modification to the library would give the user the ability to modify these parameters.  But that opens another can of worms, because sensibly modifying those parameters requires some engineering knowledge.  But this change would give greater stability to users who simply start with the demo code and move on from there without digging into the datasheets.